### PR TITLE
use ruby icon for rake files

### DIFF
--- a/src/icons/fileExtensions.ts
+++ b/src/icons/fileExtensions.ts
@@ -426,6 +426,7 @@ export default {
   "routes.jsx": "_f_routing",
   rb: "_f_ruby",
   erb: "_f_ruby",
+  rake: "_f_ruby",
   rs: "_f_rust",
   san: "_f_san",
   sas: "_f_sas",


### PR DESCRIPTION
This change adds icon support for rake files. I'm just using the ruby icon.

Behavior _before_ this change:
<img width="263" alt="Screen Shot 2022-07-03 at 11 29 14 PM" src="https://user-images.githubusercontent.com/7866287/177076741-5988f03f-249c-4368-817f-b836977e5023.png">

...and _after_ this change:
<img width="261" alt="Screen Shot 2022-07-03 at 11 41 22 PM" src="https://user-images.githubusercontent.com/7866287/177077664-df51b494-93a9-4c41-b94d-38b712edd5b2.png">


Everything was tested and working locally!