### PR TITLE
support plural form of store folder (stores)

### DIFF
--- a/src/icons/folderNames.ts
+++ b/src/icons/folderNames.ts
@@ -99,6 +99,7 @@ export default {
   context: "_fd_folder_context",
   contexts: "_fd_folder_context",
   store: "_fd_folder_context",
+  stores: "_fd_folder_context",
   contract: "_fd_folder_contract",
   contracts: "_fd_folder_contract",
   ".contract": "_fd_folder_contract",

--- a/src/icons/folderNamesExpanded.ts
+++ b/src/icons/folderNamesExpanded.ts
@@ -99,6 +99,7 @@ export default {
   context: "_fd_folder_context_open",
   contexts: "_fd_folder_context_open",
   store: "_fd_folder_context_open",
+  stores: "_fd_folder_context_open",
   contract: "_fd_folder_contract_open",
   contracts: "_fd_folder_contract_open",
   ".contract": "_fd_folder_contract_open",


### PR DESCRIPTION
This PR will simply add missing plural form of `store` folder (stores) which is the new convention of [Vue 3's Pinia](https://pinia.vuejs.org/) State manager.

Before:
![stores-before](https://user-images.githubusercontent.com/88786674/178469589-5f7915b2-d1ab-499c-b302-b3905e2e5a0f.png)

After:
![stores-after](https://user-images.githubusercontent.com/88786674/178469627-fe00c055-16f4-4b8a-9526-ccd22a623905.png)
 