### PR TITLE
Add support for `.graphql` file extension

### DIFF
--- a/src/icons/fileExtensions.ts
+++ b/src/icons/fileExtensions.ts
@@ -218,6 +218,7 @@ export default {
   gradle: "_f_gradle",
   gr: "_f_grain",
   graphcool: "_f_graphcool",
+  graphql: "_f_graphql",
   gql: "_f_graphql",
   groovy: "_f_groovy",
   h: "_f_h",


### PR DESCRIPTION
Currently, this extension only supports the `.gql` file extension for graphql files. 
This change adds file icon support for the `.graphql` file extension.