### PR TITLE
Add "forums" keyword for folder and open folder

### DIFF
--- a/src/icons/folderNames.ts
+++ b/src/icons/folderNames.ts
@@ -366,6 +366,7 @@ export default {
   messages: "_fd_folder_messages",
   messaging: "_fd_folder_messages",
   forum: "_fd_folder_messages",
+  forums: "_fd_folder_messages",
   chat: "_fd_folder_messages",
   chats: "_fd_folder_messages",
   conversation: "_fd_folder_messages",

--- a/src/icons/folderNamesExpanded.ts
+++ b/src/icons/folderNamesExpanded.ts
@@ -365,6 +365,7 @@ export default {
   messages: "_fd_folder_messages_open",
   messaging: "_fd_folder_messages_open",
   forum: "_fd_folder_messages_open",
+  forums: "_fd_folder_messages_open",
   chat: "_fd_folder_messages_open",
   chats: "_fd_folder_messages_open",
   conversation: "_fd_folder_messages_open",


### PR DESCRIPTION
Since the "forum" icon uses `_fd_folder_messages` and `_fd_folder_messages_open` this commit adds them for the keyword "forums" as well

Also resolves #78 